### PR TITLE
Update gradle wrapper download link

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-4.4-20171031235950+0000-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip


### PR DESCRIPTION
distributionUrl points to a snapshot which is not available anymore,
causing the wrapper to fail initializing itself. This change sets
distributionUrl to a URL of a binary release of the same version 4.4
which is still available.