### PR TITLE
add Android.mk to compile with aosp

### DIFF
--- a/app/src/main/Android.mk
+++ b/app/src/main/Android.mk
@@ -1,0 +1,30 @@
+# Copyright (C) 2012 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE_TAGS := tests
+LOCAL_SRC_FILES := $(call all-java-files-under, java)
+LOCAL_PACKAGE_NAME := AdbJoinWifi
+LOCAL_RESOURCE_DIR := $(LOCAL_PATH)/res
+LOCAL_USE_AAPT2 := true
+LOCAL_SDK_VERSION := current
+
+LOCAL_STATIC_ANDROID_LIBRARIES := \
+    android-support-v7-appcompat \
+
+include $(BUILD_PACKAGE)
+


### PR DESCRIPTION
as not debuggable application

Some notes:

1. LOCAL_SDK_VERSION
    when LOCAL_SDK_VERSION := 26 instead of current,
    following error would be reported:
    out/soong/.intermediates/prebuilts/sdk/current/support/android-support-v7-appcompat-nodeps/android_common/aar/res/values-v28/values-v28.xml:7: error: resource android:attr/dialogCornerRadius not found.
    out/soong/.intermediates/prebuilts/sdk/current/support/android-support-v7-appcompat-nodeps/android_common/aar/res/values-v28/values-v28.xml:11: error: resource android:attr/dialogCornerRadius not found.
    out/soong/.intermediates/prebuilts/sdk/current/support/android-support-compat-nodeps/android_common/aar/res/values/values.xml:79: error: resource android:attr/fontVariationSettings not found.
    out/soong/.intermediates/prebuilts/sdk/current/support/android-support-compat-nodeps/android_common/aar/res/values/values.xml:80: error: resource android:attr/ttcIndex not found.
    error: failed linking references.

2. LOCAL_USE_AAPT2 := true
    If we do not have it sepcified, following error would be reported:
    packages/apps/adb-join-wifi/res/values/styles.xml:4: error: Error retrieving parent for item: No resource found that matches the given name 'Theme.AppCompat.Light.DarkActionBar'.
    packages/apps/adb-join-wifi/res/values/styles.xml:8: error: Error: No resource found that matches the given name: attr 'colorAccent'.
    packages/apps/adb-join-wifi/res/values/styles.xml:6: error: Error: No resource found that matches the given name: attr 'colorPrimary'.
    packages/apps/adb-join-wifi/res/values/styles.xml:7: error: Error: No resource found that matches the given name: attr 'colorPrimaryDark'.

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>