### PR TITLE
Android.mk: make it possible to install it to Oreo 8.1

### DIFF
--- a/app/src/main/Android.mk
+++ b/app/src/main/Android.mk
@@ -21,7 +21,9 @@ LOCAL_SRC_FILES := $(call all-java-files-under, java)
 LOCAL_PACKAGE_NAME := AdbJoinWifi
 LOCAL_RESOURCE_DIR := $(LOCAL_PATH)/res
 LOCAL_USE_AAPT2 := true
-LOCAL_SDK_VERSION := current
+LOCAL_SDK_VERSION := 27
+LOCAL_SDK_RES_VERSION := current
+LOCAL_MIN_SDK_VERSION := 16
 
 LOCAL_STATIC_ANDROID_LIBRARIES := \
     android-support-v7-appcompat \


### PR DESCRIPTION
with LOCAL_SDK_VERSION set to 27 and LOCAL_SDK_RES_VERSION set to current,

making it possible to build under Pie codebase,
and the generated apk file could be installed into Oreo 8.1 device as well.

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>